### PR TITLE
Add colour schemes

### DIFF
--- a/Preferences.sublime-settings
+++ b/Preferences.sublime-settings
@@ -1,0 +1,3 @@
+{
+  "gitblame.scheme": "dark"
+}


### PR DESCRIPTION
Allow you to flip colour schemes, based on preferences
You can add `"gitblame.scheme": "light"` or `"gitblame.scheme": "dark"` (default) to your user preferences.

Dark:
![image](https://cloud.githubusercontent.com/assets/1134201/23709854/acfe8ed0-0412-11e7-8329-3aa51e530d19.png)

Light:
![image](https://cloud.githubusercontent.com/assets/1134201/23709870/bcde89cc-0412-11e7-9464-3f97713bf747.png)
Light: (with a light theme)
![image](https://cloud.githubusercontent.com/assets/1134201/23709882/ce0c2ea2-0412-11e7-9bac-e5297629a15a.png)


Closes #5 