### PR TITLE
Don't just silently fail if git fails

### DIFF
--- a/git-blame.py
+++ b/git-blame.py
@@ -61,9 +61,12 @@ class BlameCommand(sublime_plugin.TextCommand):
             return shell(["git", "blame", "--minimal", "-w",
                 "-L {0},{0}".format(line), path],
                 cwd=os.path.dirname(os.path.realpath(path)),
-                startupinfo=si)
+                startupinfo=si,
+                stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            print("Git blame: git error {}:\n{}".format(e.returncode, e.output.decode("UTF-8")))
         except Exception as e:
-            return
+            print("Git blame: Unexpected error:", e)
 
     def parse_blame(self, blame):
         sha, file_path, user, date, time, tz_offset, *_ = blame.decode('utf-8').split()


### PR DESCRIPTION
I thought the package didn't work, because nothing happened and there was no messages in the console. But it turns out the machine I was working on didn't have a recent version of git. This patch changes the package to echo out the git error to the sublime text console if this happens.

Incidentally, I can't find any documentation for the `--minimal` argument to `git blame`. Does it change the output significantly?