### PR TITLE
borrow styling from exec.py

### DIFF
--- a/Preferences.sublime-settings
+++ b/Preferences.sublime-settings
@@ -1,3 +1,0 @@
-{
-  "gitblame.scheme": "dark"
-}

--- a/README.md
+++ b/README.md
@@ -16,4 +16,6 @@ View on [packagecontrol.io](https://packagecontrol.io/packages/Git%20blame)
  
  > Right click > Git blame
  
+## Example
+
  ![image](https://user-images.githubusercontent.com/2543659/28410198-331b1ec8-6d3d-11e7-9ac1-57d43fb6ab60.png)

--- a/README.md
+++ b/README.md
@@ -16,17 +16,3 @@ View on [packagecontrol.io](https://packagecontrol.io/packages/Git%20blame)
  
  > Right click > Git blame
  
-
-## Examples
-
-
-### Light scheme
-![image](https://cloud.githubusercontent.com/assets/1134201/23709870/bcde89cc-0412-11e7-9464-3f97713bf747.png)
-
-Light: (with a light theme)
-
-![image](https://cloud.githubusercontent.com/assets/1134201/23709882/ce0c2ea2-0412-11e7-9bac-e5297629a15a.png)
-
-
-### Dark scheme
-![image](https://cloud.githubusercontent.com/assets/1134201/23709854/acfe8ed0-0412-11e7-8329-3aa51e530d19.png)

--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ View on [packagecontrol.io](https://packagecontrol.io/packages/Git%20blame)
  
  > Right click > Git blame
  
+ ![image](https://user-images.githubusercontent.com/2543659/28410198-331b1ec8-6d3d-11e7-9ac1-57d43fb6ab60.png)

--- a/git-blame.py
+++ b/git-blame.py
@@ -5,41 +5,57 @@ import functools
 import subprocess
 from subprocess import check_output as shell
 
-
-template_scheme = {}
-template_scheme['light'] = '''
-<style>
-span {
-    background-color: #aee;
-    color: #444;
-}
-strong, a {
-    text-decoration: none;
-    color: #000;
-}
-</style>
-'''
-template_scheme['dark'] = '''
-<style>
-span {
-    background-color: brown;
-}
-a {
-    text-decoration: none;
-}
-</style>
+stylesheet = '''
+    <style>
+        div.blame-arrow {
+            border-top: 0.4rem solid transparent;
+            border-left: 0.5rem solid color(var(--greenish) blend(var(--background) 30%));
+            width: 0;
+            height: 0;
+        }
+        div.blame {
+            padding: 0.4rem 0 0.4rem 0.7rem;
+            margin: 0 0 0.2rem;
+            border-radius: 0 0.2rem 0.2rem 0.2rem;
+            background-color: color(var(--greenish) blend(var(--background) 30%));
+        }
+        div.blame span.message {
+            padding-right: 0.7rem;
+        }
+        div.blame a {
+            text-decoration: inherit;
+        }
+        div.blame a.close {
+            padding: 0.35rem 0.7rem 0.45rem 0.8rem;
+            position: relative;
+            bottom: 0.05rem;
+            border-radius: 0 0.2rem 0.2rem 0;
+            font-weight: bold;
+        }
+        html.dark div.blame a.close {
+            background-color: #00000018;
+        }
+        html.light div.blame a.close {
+            background-color: #ffffff18;
+        }
+    </style>
 '''
 
 template = '''
-<span>
-{scheme}
-&nbsp;<strong>Git Blame:</strong> ({user})
+<body>
+{stylesheet}
+<div class="blame-arrow"></div>
+<div class="blame">
+<span class="message">
+<strong>Git Blame:</strong> ({user})
 Updated: {date} {time} |
 {sha}
 <a href="copy-{sha}">[Copy]</a>
 <a href="show-{sha}">[Show]</a>
-<a href="close"><close>[X]</close></a>&nbsp;
+<a class="close" href="close">''' + chr(0x00D7) + '''</a>
 </span>
+</div>
+</body>
 '''
 
 # Sometimes this fails on other OS, just error silently
@@ -130,11 +146,7 @@ class BlameCommand(sublime_plugin.TextCommand):
 
             sha, user, date, time = self.parse_blame(result)
 
-            settings = sublime.load_settings('Preferences.sublime-settings')
-            scheme_color = settings.get('gitblame.scheme') or 'dark'
-
-            body = template.format(sha=sha, user=user, date=date, time=time,
-                scheme=template_scheme.get(scheme_color, ''))
+            body = template.format(sha=sha, user=user, date=date, time=time, stylesheet=stylesheet)
 
             phantom = sublime.Phantom(line, body, sublime.LAYOUT_BLOCK, self.on_phantom_close)
             phantoms.append(phantom)


### PR DESCRIPTION
I adapted the styling from from [exec.py](http://www.sublimetext.com/docs/3/api_reference.html#example_plugins), which provides the phantoms for Sublime's build system output. It uses built-in variables to match the selected color scheme, so it always looks great and doesn't require configuration.

Some screenshots using various color schemes:

<img width="645" alt="screen shot 2017-07-20 at 11 12 51" src="https://user-images.githubusercontent.com/2543659/28410198-331b1ec8-6d3d-11e7-9ac1-57d43fb6ab60.png">
<img width="672" alt="screen shot 2017-07-20 at 11 13 05" src="https://user-images.githubusercontent.com/2543659/28410200-33312740-6d3d-11e7-8b1e-f46ae7b6925b.png">
<img width="660" alt="screen shot 2017-07-20 at 11 13 20" src="https://user-images.githubusercontent.com/2543659/28410201-3336ad3c-6d3d-11e7-974c-fa5a1f89ea2b.png">
<img width="663" alt="screen shot 2017-07-20 at 11 13 29" src="https://user-images.githubusercontent.com/2543659/28410203-3358c444-6d3d-11e7-980d-e4b49958eb9b.png">
<img width="667" alt="screen shot 2017-07-20 at 11 13 38" src="https://user-images.githubusercontent.com/2543659/28410202-333ccc62-6d3d-11e7-8d7f-ff88067f3cb1.png">
