### PR TITLE
Trim decoration to make X reachable in 80col views

### DIFF
--- a/git-blame.py
+++ b/git-blame.py
@@ -47,8 +47,8 @@ template = '''
         <div class="phantom-arrow"></div>
         <div class="phantom">
             <span class="message">
-                <strong>Git Blame:</strong> ({user})
-                Updated: {date} {time} |
+                <strong>Git Blame</strong> ({user})
+                {date} {time} |
                 {sha}
                 <a href="copy-{sha}">[Copy]</a>
                 <a href="show-{sha}">[Show]</a>
@@ -162,4 +162,3 @@ class InsertCommitDescriptionCommand(sublime_plugin.TextCommand):
         view.set_scratch(True)
         view.set_syntax_file('Packages/Diff/Diff.sublime-syntax')
         view.insert(edit, 0, desc)
-


### PR DESCRIPTION
The phantom has gotten pretty wide :)

When using Sublime with e.g. 3 side-by-side views, it was likely that the [X]s were far enough to the right that the horizontal scrollbar needed to be used to find them.