### PR TITLE
BlameCommand: Notice when the file is unsaved:

### DIFF
--- a/git-blame.py
+++ b/git-blame.py
@@ -176,6 +176,10 @@ class BlameCommand(sublime_plugin.TextCommand):
             self.view.erase_phantoms('git-blame')
 
     def run(self, edit):
+        if self.view.is_dirty():
+            sublime.status_message("The file needs to be saved for git blame.")
+            return
+
         phantoms = []
         self.view.erase_phantoms('git-blame')
         #Before adding the phantom, see if the current phantom that is displayed is at the same spot at the selection


### PR DESCRIPTION
Querying blame information for a file with unsaved modifications shouldn't be allowed. This is because the line-number of the text caret in the in-memory representation of the file has a high chance of referring to an unrelated line in the on-disk representation of the file. Since `git blame` operates solely with on-disk representation, bogus information could be shown in the phantom because of this discrepancy.

BlameShowAllCommand already protects against this.